### PR TITLE
Bugfix for other language models

### DIFF
--- a/speech_to_text/__init__.py
+++ b/speech_to_text/__init__.py
@@ -50,7 +50,7 @@ def recognize_speech(username, password, audio_file_path,
     }
 
     default_options = build_default_options(
-        audio_model=audio_model,
+        model=audio_model,
         inactivity_timeout=inactivity_timeout)
     kwargs.update(default_options)
     kwargs.update(extra_options or {})

--- a/speech_to_text/formatters.py
+++ b/speech_to_text/formatters.py
@@ -35,7 +35,7 @@ class HTMLFormatter(BaseFormatter):
         results = (obj['transcript']
                    for obj in self._parse(data))
         lines = ("{spaces}<p>{line}</p>\n".format(
-            spaces=(' ' * 4), line=line) for line in results)
+            spaces=(' ' * 4), line=line.encode('utf-8')) for line in results)
         return "<html>\n{}</html>".format(''.join(lines))
 
 
@@ -43,7 +43,7 @@ class MarkdownFormatter(BaseFormatter):
     def format(self, data):
         results = (obj['transcript']
                    for obj in self._parse(data))
-        lines = ("{line}\n\n".format(line=line) for line in results)
+        lines = ("{line}\n\n".format(line=line.encode('utf-8')) for line in results)
 
         return ''.join(lines).rstrip()
 


### PR DESCRIPTION
- Fix the model parameter as stated in Watson API https://www.ibm.com/watson/developercloud/speech-to-text/api/v1/python.html?python#create-job. Solves issue #6 
- Fix the character encoding bug in formatters when working with strings with accents. No issue related.